### PR TITLE
Switch to pychrome for Chrome PDF rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Install using `pip`...
 
 Example settings:
 
+    CHROME_URL = 'http://localhost:9222'
     ORGANIZATION_MODEL = 'myapp.Organization'
     REPORT_PACKAGES = ('myapp.reports', )  # Packages were reports can be found
     INSTALLED_APPS = (
@@ -37,6 +38,14 @@ Example settings:
         'django_celery_beat',
         'reports',
     )
+
+For generating PDF reports you must have a Chrome/Chromium browser instance running:
+
+    google-chrome --remote-debugging-port=9222
+
+or headless mode:
+
+    google-chrome --headless --disable-gpu --remote-debugging-port=9222
 
 You will then have to create an API to manage these. More docs to come...
 

--- a/setup.py
+++ b/setup.py
@@ -65,11 +65,10 @@ setup(
     install_requires=[
         'django',
         'python-dateutil',
-        'pathlib;python_version<"3.4"',
-        'django-hardcopy',
         'django-celery-beat',
         'jsonfield',
-        'pypandoc'
+        'pypandoc',
+        'pychrome'
     ],
     classifiers=[
         'Development Status :: 4 - Beta',
@@ -83,4 +82,3 @@ setup(
         'Topic :: Internet :: WWW/HTTP',
     ]
 )
-

--- a/tox.ini
+++ b/tox.ini
@@ -9,11 +9,10 @@ commands = {envpython} reports/runtests/runtests.py
 deps =
     psycopg2-binary
     python-dateutil
-    pathlib
-    django-hardcopy
     django-celery-beat
     jsonfield
     pypandoc
+    pychrome
     mock
 
 [testenv:django1.11]


### PR DESCRIPTION
Pychrome uses the Chrome Devtools protocol to print page as PDF. This gives us more flexibility to customize PDF print options. Also this library can work with containerized Chrome.