### PR TITLE
Retry failed report

### DIFF
--- a/reports/__init__.py
+++ b/reports/__init__.py
@@ -1,2 +1,2 @@
-__version__ = '0.0.11'
+__version__ = '0.0.12'
 VERSION = __version__

--- a/reports/tasks.py
+++ b/reports/tasks.py
@@ -14,7 +14,10 @@ def generate_document(self, report_id):
     Generates the report document. Retry after 1 minute
     """
 
-    report = Report.objects.get(pk=report_id)
+    try:
+        report = Report.objects.get(pk=report_id)
+    except Report.DoesNotExist as exc:
+        raise self.retry(exc=exc, max_retries=3)
     try:
         report.generate_document()
     except Exception as exc:


### PR DESCRIPTION
When a `Report` isn't found, it could be because Rabbit is faster in Postgres :) (rabbits do tend to be faster than elephants). Let's retry a couple of times before, we give up. It's an elephant, not a tortoise, so hopefully 180 seconds delay should be sane