### PR TITLE
fix: use `--reference-doc` to convert markdown to doc

### DIFF
--- a/reports/base.py
+++ b/reports/base.py
@@ -48,7 +48,7 @@ class BaseReport(object):
             extra_args = ['--dpi=180']
             if typ == 'docx':
                 if reference:
-                    extra_args.append('--reference-docx={}'.format(reference))
+                    extra_args.append('--reference-doc={}'.format(reference))
                 extra_args.append('--toc')
             convert_text(markdown, typ, 'markdown_phpextra',
                          outputfile=temp.name, extra_args=extra_args)


### PR DESCRIPTION
- `--reference-docx` has been remove from the `pandoc`, so we should
use `--reference-doc` instead of it.

Resolves #10