### PR TITLE
Do not include configurable changes to Report in schemamigrations

### DIFF
--- a/reports/conf.py
+++ b/reports/conf.py
@@ -1,9 +1,20 @@
+import sys
 from django.conf import settings
 
-ORG_MODEL = getattr(settings, 'ORGANIZATION_MODEL', 'report.Organization')
-REPORT_PACKAGES = getattr(settings, 'REPORT_PACKAGES', [])
-TYPE_CHOICES = getattr(settings, 'REPORT_TYPE_CHOICES', (
+_DEFAULT_ORG_MODEL = 'report.Organization'
+_DEFAULT_REPORT_PACKAGES = []
+_DEFAULT_TYPE_CHOICES = (
     ('pdf', 'PDF Document'),
     ('docx', 'Word Document'),
     ('xlsx', 'Excel Document'),
-))
+)
+
+if 'schemamigration' in sys.argv:
+    ORG_MODEL = _DEFAULT_ORG_MODEL
+    REPORT_PACKAGES = _DEFAULT_REPORT_PACKAGES
+    TYPE_CHOICES = _DEFAULT_TYPE_CHOICES
+
+
+ORG_MODEL = getattr(settings, 'ORGANIZATION_MODEL', _DEFAULT_ORG_MODEL)
+REPORT_PACKAGES = getattr(settings, 'REPORT_PACKAGES', _DEFAULT_REPORT_PACKAGES)
+TYPE_CHOICES = getattr(settings, 'REPORT_TYPE_CHOICES', _DEFAULT_TYPE_CHOICES)


### PR DESCRIPTION
Someone commited report choices from our product in the migration. This change prevents this kind of commits