### PR TITLE
Fixes TypeError in quarterly schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,16 @@ That's it, we're done!
 
 [build-status-image]: https://secure.travis-ci.org/AdvancedThreatAnalytics/django-libreports.png?branch=master
 [travis]: http://travis-ci.org/AdvancedThreatAnalytics/django-libreports?branch=master
+
+# Development
+
+### Setting up
+Setup dependencies
+```
+pip install -r requirements.txt
+```
+### Running tests
+
+```
+python3 tests/runtests.py
+```

--- a/reports/__init__.py
+++ b/reports/__init__.py
@@ -1,2 +1,2 @@
-__version__ = '0.1.1'
+__version__ = '0.1.2'
 VERSION = __version__

--- a/reports/models.py
+++ b/reports/models.py
@@ -293,6 +293,7 @@ class ReportSchedule(BaseReportModel):
         Constructs crontab format schedule based on a period and stores
             it on schedule field
         """
+        # If a schedule is defined, pull from that
         if self.report_datetime:
             minute = str(self.report_datetime.minute)
             hour = str(self.report_datetime.hour)
@@ -335,7 +336,7 @@ class ReportSchedule(BaseReportModel):
             })
         elif self.period == self.PERIOD_QUARTERLY:
             # Runs every 1st day of a quarter at 6am
-            month_of_year = month_of_year % 3
+            month_of_year = int(month_of_year) % 3
             if not month_of_year:
                 month_of_year = '*'
 

--- a/reports/tests/models_schedule_report.py
+++ b/reports/tests/models_schedule_report.py
@@ -177,6 +177,19 @@ class ScheduleReportModelTestCase(TestCase):
             'month_of_year': '*'
         })
 
+        # Quarterly
+        quarterly = ReportSchedule(organization=org)
+        quarterly.period = ReportSchedule.PERIOD_QUARTERLY
+        quarterly.report_datetime = datetime(2010, 10, 10, 10, 10, 10)
+        quarterly.set_schedule()
+        self.assertEquals(quarterly.schedule, {
+            'day_of_month': '10',
+            'day_of_week': '*',
+            'hour': '10',
+            'minute': '10',
+            'month_of_year': '1/3'
+        })
+
         # Yearly
         yearly = ReportSchedule(organization=org)
         yearly.period = ReportSchedule.PERIOD_YEARLY
@@ -188,6 +201,27 @@ class ScheduleReportModelTestCase(TestCase):
             'hour': '10',
             'minute': '10',
             'month_of_year': '10'
+        })
+
+    def test_quarterly_task_no_datetime_returns_valid_schedule(self):
+
+        org = Organization.objects.create(name='Org')
+
+        # Quarterly
+        quarterly = ReportSchedule(organization=org)
+        quarterly.period = ReportSchedule.PERIOD_QUARTERLY
+
+        # Test that when report_datetime is None, the schedule is valid
+        quarterly.report_datetime = None
+        quarterly.set_schedule()
+
+        # Should run at 6:00AM, first day of the month, every 3 months
+        self.assertEquals(quarterly.schedule, {
+            'day_of_month': '1',
+            'day_of_week': '*',
+            'hour': '6',
+            'minute': '0',
+            'month_of_year': '1/3'
         })
 
     def test_periodic_task_kwargs(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+celery
+django
+django-celery-beat
+jsonfield
+pychrome
+pypandoc
+psycopg2


### PR DESCRIPTION
This fixes a case where `report_datetime` was `None`, where we tried to do integer arithmetic against a string. 