### PR TITLE
Encode the content of the report when the ReportSkipped exception is raised.

### DIFF
--- a/reports/models.py
+++ b/reports/models.py
@@ -166,8 +166,8 @@ class Report(BaseReportModel):
 
             self.document.save(
                 name,
-                ContentFile(f"Report generation was "
-                            f"skipped: {ex.reason}"),
+                ContentFile((f"Report generation was "
+                            f"skipped: {ex.reason}").encode('utf-8')),
                 save=False
             )
             self.save()


### PR DESCRIPTION
Related to issue: https://github.com/AdvancedThreatAnalytics/ata_portal/issues/8283