### PR TITLE
Modify the cron job for quarterly scheduled reports.

### DIFF
--- a/reports/models.py
+++ b/reports/models.py
@@ -404,10 +404,6 @@ class ReportSchedule(BaseReportModel):
             )
         elif self.period == self.PERIOD_QUARTERLY:
             # Runs every 1st day of a quarter at 6am
-            month_of_year = int(month_of_year) % 3
-            if not month_of_year:
-                month_of_year = '*'
-
             self.schedule.update(
                 {
                     'day_of_week': '*',

--- a/reports/models.py
+++ b/reports/models.py
@@ -412,7 +412,7 @@ class ReportSchedule(BaseReportModel):
                 {
                     'day_of_week': '*',
                     'day_of_month': day_of_month,
-                    'month_of_year': '{}/3'.format(month_of_year)
+                    'month_of_year': '*/3'
                 }
             )
         elif self.period == self.PERIOD_YEARLY:

--- a/reports/tests/models_schedule_report.py
+++ b/reports/tests/models_schedule_report.py
@@ -134,6 +134,18 @@ class ScheduleReportModelTestCase(TestCase):
             'month_of_year': '1'
         })
 
+        # Quarterly
+        quarterly = ReportSchedule(organization=org)
+        quarterly.period = ReportSchedule.PERIOD_QUARTERLY
+        quarterly.set_schedule()
+        self.assertEquals(quarterly.schedule, {
+            'minute': '0',
+            'hour': '6',
+            'day_of_week': '*',
+            'day_of_month': '1',
+            'month_of_year': '*/3'
+        })
+
     def test_set_schedule_choosen_date(self):
 
         org = Organization.objects.create(name='Org')
@@ -187,7 +199,7 @@ class ScheduleReportModelTestCase(TestCase):
             'day_of_week': '*',
             'hour': '10',
             'minute': '10',
-            'month_of_year': '1/3'
+            'month_of_year': '*/3'
         })
 
         # Yearly
@@ -221,7 +233,7 @@ class ScheduleReportModelTestCase(TestCase):
             'day_of_week': '*',
             'hour': '6',
             'minute': '0',
-            'month_of_year': '1/3'
+            'month_of_year': '*/3'
         })
 
     def test_periodic_task_kwargs(self):


### PR DESCRIPTION
Related to issue: https://github.com/AdvancedThreatAnalytics/ata_portal/issues/8479


The cron job for a quarterly scheduled report should be of the format: 
![image](https://user-images.githubusercontent.com/51012268/115575384-1fefe700-a288-11eb-90d5-f64878d2a7b9.png)
