### PR TITLE
CERB-2888 - Update to support Django 4.2 and Python 3.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
-FROM 818476207984.dkr.ecr.us-west-2.amazonaws.com/advancedthreatanalytics/python-slim:latest
+FROM 818476207984.dkr.ecr.us-west-2.amazonaws.com/advancedthreatanalytics/python-slim:3.11-build
 MAINTAINER infrastructure@advancedthreatanalytics.com
+
+ARG PIP_INDEX_URL
+
+RUN pip install tox
 
 COPY reports /opt/app/reports/
 COPY setup.py tox.ini /opt/app/
-
-RUN pip install tox
 
 WORKDIR /opt/app

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -5,18 +5,31 @@ env:
 phases:
   install:
     runtime-versions:
-      python: 3.10
+      python: 3.11
   pre_build:
     commands:
-      - export COMPOSE_FILE=docker-compose.codebuild.yml
-      - aws codeartifact login --tool pip --domain criticalstart --domain-owner 818476207984 --repository criticalstart_global
+      - export CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain criticalstart --domain-owner 818476207984 --query authorizationToken --duration-seconds 1800 --output text)
+      - export PIP_INDEX_URL="https://aws:${CODEARTIFACT_AUTH_TOKEN}@criticalstart-818476207984.d.codeartifact.us-west-2.amazonaws.com/pypi/criticalstart_global/simple/"
       - pip install black
       - pip install -r requirements-build.txt
       - REPOSITORY_BASE=818476207984.dkr.ecr.us-west-2.amazonaws.com
       - AWS_DEFAULT_REGION=us-west-2
       - aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin $REPOSITORY_BASE
+
+      - REPOSITORY_BASE=818476207984.dkr.ecr.us-west-2.amazonaws.com
+      - echo Logging in to Amazon ECR...
+      - aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin $REPOSITORY_BASE
+      - echo Logging in to Amazon CodeArtifact...
+      - export CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain criticalstart --domain-owner 818476207984 --query authorizationToken --duration-seconds 1800 --output text)
+      - export PIP_INDEX_URL="https://aws:${CODEARTIFACT_AUTH_TOKEN}@criticalstart-818476207984.d.codeartifact.us-west-2.amazonaws.com/pypi/criticalstart_global/simple/"
+
+      # Build dependencies
+      - pip install -r requirements-build.txt
+
+      # Build environment
+      - export COMPOSE_FILE=docker-compose.codebuild.yml
       - docker-compose up -d postgres
-      - docker-compose build app
+      - docker-compose build --build-arg PIP_INDEX_URL app
   build:
     commands:
       - black --check .

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -10,7 +10,7 @@ phases:
     commands:
       - export CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain criticalstart --domain-owner 818476207984 --query authorizationToken --duration-seconds 1800 --output text)
       - export PIP_INDEX_URL="https://aws:${CODEARTIFACT_AUTH_TOKEN}@criticalstart-818476207984.d.codeartifact.us-west-2.amazonaws.com/pypi/criticalstart_global/simple/"
-      - pip install black
+      - pip install black==23.1.0
       - pip install -r requirements-build.txt
       - REPOSITORY_BASE=818476207984.dkr.ecr.us-west-2.amazonaws.com
       - AWS_DEFAULT_REGION=us-west-2

--- a/docker-compose.codebuild.yml
+++ b/docker-compose.codebuild.yml
@@ -6,8 +6,11 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      args:
+        - PIP_INDEX_URL
     environment:
         - AWS_DEFAULT_REGION=us-west-2
+        - PIP_INDEX_URL=${PIP_INDEX_URL}
     networks:
         - codebuild
   postgres:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-libreport"
-version = "0.0.10"
+version = "0.0.11"
 authors = [
   { name="CriticalSTART", email="infrastructure@criticalstart.com" },
 ]

--- a/reports/runtests/settings.py
+++ b/reports/runtests/settings.py
@@ -84,3 +84,6 @@ AUTH_USER_MODEL = "auth.User"
 CELERY_ALWAYS_EAGER = True
 CELERY_EAGER_PROPAGATES_EXCEPTIONS = True
 ORGANIZATION_MODEL = "example.Organization"
+
+DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
+

--- a/reports/runtests/settings.py
+++ b/reports/runtests/settings.py
@@ -86,4 +86,3 @@ CELERY_EAGER_PROPAGATES_EXCEPTIONS = True
 ORGANIZATION_MODEL = "example.Organization"
 
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ django>=3.2
 django-celery-beat
 pychrome
 pypandoc
-psycopg2

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,6 @@ setup(
     name="django-libreports",
     version=version,
     url="http://github.com/AdvancedThreatAnalytics/django-libreport",
-    license="BSD",
     description="Django app to allow creating custom reports easily.",
     author="Advanced Threat Analytics Inc.",
     author_email="simon@advancedthreatanalytics.com",  # SEE NOTE BELOW (*)

--- a/tox.ini
+++ b/tox.ini
@@ -2,20 +2,29 @@
 toxworkdir = {env:HOME}/.cache/tox/reports
 downloadcache = {toxworkdir}/cache/
 envlist =
-	py3.8-django3
+	py3.11-django4.2
+	py3.8-django3.2
 
 [testenv]
 commands = {envpython} reports/runtests/runtests.py
 deps =
-    psycopg2-binary
     python-dateutil
     django-celery-beat
     pypandoc
     pychrome
     mock
 
-[testenv:py3.8-django3]
+[testenv:py3.11-django4.2]
+basepython = python3.11
+deps =
+    psycopg
+    psycopg-binary
+    django>=4.2,<4.3
+    {[testenv]deps}
+
+[testenv:py3.8-django3.2]
 basepython = python3.8
 deps =
+    psycopg2
     django>=3.2,<4.0
     {[testenv]deps}


### PR DESCRIPTION
Update version to 0.0.11

* Add build for Python 3.11
* Update buildpsec
* Update build image
* Remove conflicting license definition