### PR TITLE
GRPH-1637-Fix weekly schedule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-libreport"
-version = "0.0.11"
+version = "0.0.12"
 authors = [
   { name="CriticalSTART", email="infrastructure@criticalstart.com" },
 ]

--- a/reports/__init__.py
+++ b/reports/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "0.0.10"
+__version__ = "0.0.12"
 VERSION = __version__

--- a/reports/models.py
+++ b/reports/models.py
@@ -355,8 +355,8 @@ class ReportSchedule(BaseReportModel):
             minute = str(self.report_datetime.minute)
             hour = str(self.report_datetime.hour)
             # Celery cron is Sunday=0, Saturday=6
-            # isoweekday() is Sunday=1, Saturday=7
-            day_of_week = str(self.report_datetime.isoweekday() - 1)
+            # isoweekday() is Monday=1, Sunday=7
+            day_of_week = str(self.report_datetime.isoweekday() % 7)
             day_of_month = str(self.report_datetime.day)
             month_of_year = str(self.report_datetime.month)
         else:

--- a/reports/tests/models_schedule_report.py
+++ b/reports/tests/models_schedule_report.py
@@ -186,13 +186,14 @@ class ScheduleReportModelTestCase(TestCase):
         # Weekly
         weekly = ReportSchedule(organization=org)
         weekly.period = ReportSchedule.PERIOD_WEEKLY
+        # This is a Sunday
         weekly.report_datetime = datetime(2010, 10, 10, 10, 10, 10)
         weekly.set_schedule()
         self.assertEquals(
             weekly.schedule,
             {
                 "day_of_month": "*",
-                "day_of_week": "6",
+                "day_of_week": "0",
                 "hour": "10",
                 "minute": "10",
                 "month_of_year": "*",


### PR DESCRIPTION
Fixes GRPH-1637

Python used the standard ISO implementation for weekdays which starts at Monday = 1 and Sunday =7. The calculation was setting the wrong date so it was generating the report a day earlier.